### PR TITLE
Fix extension metadata

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -9,3 +9,4 @@ repository = "https://github.com/j4ng5y/zed_golangci_lint"
 [language_servers.golangci-lint]
 name = "golangci-lint"
 language = "Golangci Lint"
+languages = ["Go"]


### PR DESCRIPTION
Just add `languages` key. Without it I get the next in my Zed logs

```
[WARN] no language server found matching 'golangci-lint'
```
